### PR TITLE
New user controller method for signIn flow

### DIFF
--- a/src/main/controller/UserController.ts
+++ b/src/main/controller/UserController.ts
@@ -72,14 +72,14 @@ export class UserController {
     next: NextFunction
   ): Promise<any> => {
     try {
-      await getManager().transaction(async (transationalEntityManager) => {
+      await getManager().transaction(async (transactionalEntityManager) => {
         const firebaseId = await FirebaseIdValidation.schema.validateAsync(
           req.params.firebaseId,
           {
             abortEarly: false,
           }
         );
-        const userRepository = transationalEntityManager.getCustomRepository(
+        const userRepository = transactionalEntityManager.getCustomRepository(
           UserRepository
         );
         const user = await userRepository.findByFirebaseId(firebaseId, {

--- a/src/main/controller/UserController.ts
+++ b/src/main/controller/UserController.ts
@@ -12,6 +12,7 @@ import { SavedPromotionRepository } from '../repository/SavedPromotionRepository
 import { DTOConverter } from '../validation/DTOConverter';
 import { SavedPromotion } from '../entity/SavedPromotion';
 import { Promotion } from '../entity/Promotion';
+import { FirebaseIdValidation } from '../validation/FirebaseIdValidation';
 
 export class UserController {
   /**
@@ -57,6 +58,33 @@ export class UserController {
           UserRepository
         );
         const user = await userRepository.findOneOrFail(id, { cache: true });
+        return res.send(user);
+      });
+    } catch (e) {
+      return next(e);
+    }
+  };
+
+  // return one user by firebaseId
+  getOneByFirebaseId = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<any> => {
+    try {
+      await getManager().transaction(async (transationalEntityManager) => {
+        const firebaseId = await FirebaseIdValidation.schema.validateAsync(
+          req.params.firebaseId,
+          {
+            abortEarly: false,
+          }
+        );
+        const userRepository = transationalEntityManager.getCustomRepository(
+          UserRepository
+        );
+        const user = await userRepository.findByFirebaseId(firebaseId, {
+          cache: true,
+        });
         return res.send(user);
       });
     } catch (e) {

--- a/src/main/repository/UserRepository.ts
+++ b/src/main/repository/UserRepository.ts
@@ -1,14 +1,7 @@
-import {
-  DeleteResult,
-  EntityRepository,
-  FindOneOptions,
-  Repository,
-  UpdateResult,
-} from 'typeorm';
+import { EntityRepository, FindOneOptions, Repository } from 'typeorm';
 import { User } from '../entity/User';
 import { Promotion } from '../entity/Promotion';
 import { SavedPromotion } from '../entity/SavedPromotion';
-import { UserUpdateDTO } from '../validation/UserUpdateValidation';
 
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {

--- a/src/main/repository/UserRepository.ts
+++ b/src/main/repository/UserRepository.ts
@@ -1,7 +1,14 @@
-import { EntityRepository, Repository } from 'typeorm';
+import {
+  DeleteResult,
+  EntityRepository,
+  FindOneOptions,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { User } from '../entity/User';
 import { Promotion } from '../entity/Promotion';
 import { SavedPromotion } from '../entity/SavedPromotion';
+import { UserUpdateDTO } from '../validation/UserUpdateValidation';
 
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
@@ -9,8 +16,11 @@ export class UserRepository extends Repository<User> {
     return this.findOne({ firstName, lastName });
   }
 
-  findByFirebaseId(firebaseId: string): Promise<User | undefined> {
-    return this.findOne({ firebaseId });
+  findByFirebaseId(
+    firebaseId: string,
+    options: FindOneOptions<User>
+  ): Promise<User | undefined> {
+    return this.findOneOrFail({ firebaseId }, options);
   }
 
   /**

--- a/src/main/route/UserRouter.ts
+++ b/src/main/route/UserRouter.ts
@@ -26,6 +26,11 @@ export class UserRouter {
       this.firebaseAuth.isAuthorizedForProtection,
       this.userController.getOneById
     );
+    this.userRouter.get(
+      '/firebase/:firebaseId',
+      this.firebaseAuth.isAuthorizedForProtection,
+      this.userController.getOneByFirebaseId
+    );
     this.userRouter.post(
       '/',
       this.firebaseAuth.isAuthorizedForProtection,

--- a/src/main/validation/FirebaseIdValidation.ts
+++ b/src/main/validation/FirebaseIdValidation.ts
@@ -1,0 +1,8 @@
+import Joi, { StringSchema } from 'joi';
+
+/**
+ * Class to validate firebase id
+ * */
+export class FirebaseIdValidation {
+  static schema: StringSchema = Joi.string().required();
+}

--- a/src/test/controller/UserController.test.ts
+++ b/src/test/controller/UserController.test.ts
@@ -24,7 +24,7 @@ describe('Unit tests for UserController', function () {
   let app: Express;
   let redisClient: RedisClient;
   let mockFirebaseAdmin: any;
-  let uid = '';
+  let firebaseId = '';
   let idToken = '';
 
   beforeAll(async () => {
@@ -44,7 +44,7 @@ describe('Unit tests for UserController', function () {
       password: 'testpassword',
     });
     idToken = await user.getIdToken();
-    uid = user.uid;
+    firebaseId = user.uid;
   });
 
   afterAll(async () => {
@@ -103,9 +103,25 @@ describe('Unit tests for UserController', function () {
       });
   });
 
+  test('GET /users/firebase/:firebaseId', async (done) => {
+    const expectedUser: User = new UserFactory().generate();
+    expectedUser.firebaseId = firebaseId;
+    await userRepository.save(expectedUser);
+    request(app)
+      .get(`/users/firebase/${expectedUser.firebaseId}`)
+      .set('Authorization', idToken)
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        const user = res.body;
+        compareUsers(user, expectedUser);
+        done();
+      });
+  });
+
   test('POST /users', async (done) => {
     const expectedUser: User = new UserFactory().generate();
-    expectedUser.firebaseId = uid;
+    expectedUser.firebaseId = firebaseId;
     const sentObj: any = { ...expectedUser };
     delete sentObj['id'];
     request(app)

--- a/src/test/repository/UserRepository.test.ts
+++ b/src/test/repository/UserRepository.test.ts
@@ -31,7 +31,10 @@ describe('Unit tests for UserRepository', function () {
   test('Should be able to store a user and successfully retrieve by id firebase', async () => {
     const expectedUser: User = new UserFactory().generate();
     await userRepository.save(expectedUser);
-    const user = await userRepository.findByFirebaseId(expectedUser.firebaseId);
+    const user = await userRepository.findByFirebaseId(
+      expectedUser.firebaseId,
+      { cache: true }
+    );
     expect(user).toBeDefined();
     expect(user!.id).toEqual(expectedUser.id);
   });


### PR DESCRIPTION
I found the bug in the current signIn flow.
Because FE signIn by firebase, the user does not have `userId` of our DB. In order to give the user `userId` in FE, I added new method in userController, `getOneByFirebaseId`.

FE can request GET `users/firebase/:firebaseId` after signIn to get user info. This endpoint is also protected.